### PR TITLE
Why should deadcode analysis ignore tests?

### DIFF
--- a/deadcode.go
+++ b/deadcode.go
@@ -38,15 +38,14 @@ func errorf(format string, args ...interface{}) {
 }
 
 func doDir(name string) {
-	notests := func(info os.FileInfo) bool {
-		if !info.IsDir() && strings.HasSuffix(info.Name(), ".go") &&
-			!strings.HasSuffix(info.Name(), "_test.go") {
+	gofiles := func(info os.FileInfo) bool {
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".go") {
 			return true
 		}
 		return false
 	}
 	fs := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fs, name, notests, parser.Mode(0))
+	pkgs, err := parser.ParseDir(fs, name, gofiles, parser.Mode(0))
 	if err != nil {
 		errorf("%s", err)
 		return


### PR DESCRIPTION
[Consider this package](https://gist.github.com/peterbourgon/09e2caf21d53e87662dc).

Expected output: `deadcode` passes.

Actual output: `deadcode: foo.go:3:1: bar is unused`

bar is not unused; it's used in tests. Is that not good enough?
